### PR TITLE
Make use of APPIMAGEHUB_URL global property

### DIFF
--- a/src/gateways/AppImageHubSource.cpp
+++ b/src/gateways/AppImageHubSource.cpp
@@ -242,7 +242,7 @@ void AppImageHubSource::disposeParsers() {
 AppImageHubSource::AppImageHubSource(DownloadManager *downloadManager,
                                      QObject *parent)
         : Source(parent), downloadManager(downloadManager) {
-    url = "https://appimage.github.io/feed.json";
+    url = APPIMAGEHUB_URL;
 }
 
 AppImageHubSource::AppImageHubSource(const QString &url,

--- a/src/gateways/AppImageHubSource.h
+++ b/src/gateways/AppImageHubSource.h
@@ -15,7 +15,7 @@
 #include "entities/Application.h"
 #include "gateways/DownloadManager.h"
 
-#define DEFAULT_APPIMAGEHUB_URL "https://appimage.github.io/feed.json"
+static const QString APPIMAGEHUB_URL = "https://appimage.github.io/feed.json";
 
 class AppImageInstallLinksRegExParser;
 


### PR DESCRIPTION
Also changes it to a global const QString. I prefer to use const classes instead of defining string literals. If you don't, I'll change it back to a `#define`.